### PR TITLE
flux-operator: Add `extraEnvs` and `hostNetwork` options

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -35,8 +35,9 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}` | Pod affinity and anti-affinity settings. |
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
+| extraEnvs | list | `[]` | Container extra environment variables. |
 | fullnameOverride | string | `""` |  |
-| hostNetwork | bool | `false` | If `true`, start flux-operator in hostNetwork mode. |
+| hostNetwork | bool | `false` | If `true`, the container ports (`8080` and `8081`) are exposed on the host network. |
 | image | object | `{"pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |
 | installCRDs | bool | `true` | Install and upgrade the custom resource definitions. |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |

--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -36,6 +36,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | fullnameOverride | string | `""` |  |
+| hostNetwork | bool | `false` | If `true`, start flux-operator in hostNetwork mode. |
 | image | object | `{"pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |
 | installCRDs | bool | `true` | Install and upgrade the custom resource definitions. |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             - name: MARKETPLACE_LICENSE
               value: {{ . }}
             {{- end }}
+            {{- if .Values.extraEnvs }}
+              {{- toYaml .Values.extraEnvs | nindent 12 }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: manager
           env:

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -74,6 +74,10 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "hostNetwork": {
+            "default": false,
+            "type": "boolean"
+        },
         "image": {
             "properties": {
                 "pullSecrets": {

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -71,6 +71,13 @@
             "properties": {},
             "type": "object"
         },
+        "extraEnvs": {
+            "items": {
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
         "fullnameOverride": {
             "type": "string"
         },

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -88,5 +88,8 @@ marketplace:
   license: ""
   account: ""
 
-# -- If `true`, start flux-operator in hostNetwork mode.
-hostNetwork: false
+# -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
+hostNetwork: false # @schema default: false
+
+# -- Container extra environment variables.
+extraEnvs: [ ] # @schema item: object ; uniqueItems: true

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -87,3 +87,6 @@ tolerations: [ ] # @schema item: object ; uniqueItems: true
 marketplace:
   license: ""
   account: ""
+
+# -- If `true`, start flux-operator in hostNetwork mode.
+hostNetwork: false


### PR DESCRIPTION
Building on #10 

[Helm chart: add extraEnvs array option](https://github.com/controlplaneio-fluxcd/charts/commit/597e086a877ee9f2c89e7f773382ce0045921ac8) (597e086a877ee9f2c89e7f773382ce0045921ac8)

I am testing this over at:

https://github.com/kingdonb/cozystack/tree/flux-operator

The cozystack installer has a way of bundling Helm charts internally so it has been relatively easy to verify this chart and check it does what we need 🌮 

Testing also here: https://github.com/kingdonb/cozystack-talm-demo