### PR TITLE
flux-operator: Add Prometheus scraping settings

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -49,6 +49,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
+| serviceMonitor | object | `{"create":false,"interval":"60s","scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |
 | tolerations | list | `[]` | Pod tolerations settings. |
 
 ## Source Code

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -18,10 +18,13 @@ spec:
       {{- include "flux-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.commonAnnotations }}
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+        {{- with .Values.commonAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "flux-operator.labels" . | nindent 8 }}
         {{- with .Values.commonLabels }}

--- a/charts/flux-operator/templates/servicemonitor.yaml
+++ b/charts/flux-operator/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "flux-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flux-operator.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "flux-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - targetPort: 8080
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -293,6 +293,25 @@
             },
             "type": "object"
         },
+        "serviceMonitor": {
+            "default": {
+                "create": false,
+                "interval": "60s",
+                "scrapeTimeout": "30s"
+            },
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "scrapeTimeout": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "tolerations": {
             "items": {
                 "type": "object"

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -84,14 +84,20 @@ affinity: # @schema default: {"nodeAffinity":{"requiredDuringSchedulingIgnoredDu
 # -- Pod tolerations settings.
 tolerations: [ ] # @schema item: object ; uniqueItems: true
 
-# -- Marketplace settings.
-marketplace:
-  type: ""
-  license: ""
-  account: ""
-
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false
 
 # -- Container extra environment variables.
 extraEnvs: [ ] # @schema item: object ; uniqueItems: true
+
+# -- Prometheus Operator scraping settings.
+serviceMonitor: # @schema default: {"create":false,"interval":"60s","scrapeTimeout":"30s"}
+  create: false
+  interval: 60s
+  scrapeTimeout: 30s
+
+# -- Marketplace settings.
+marketplace:
+  type: ""
+  license: ""
+  account: ""


### PR DESCRIPTION
Allow creating Prometheus ServiceMonitor resource.

xref: https://github.com/controlplaneio-fluxcd/flux-operator/pull/54