### PR TITLE
Add flux-instance chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This repository contains the Helm charts for the ControlPlane Flux CD projects.
 ## Charts
 
 - [flux-operator](charts/flux-operator/README.md)
+- [flux-instance](charts/flux-instance/README.md)

--- a/charts/flux-instance/.helmignore
+++ b/charts/flux-instance/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+helmdocs.gotmpl

--- a/charts/flux-instance/Chart.yaml
+++ b/charts/flux-instance/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+version: 0.0.1
+appVersion: "v0.0.1"
+kubeVersion: ">=1.22.0-0"
+type: application
+name: flux-instance
+description: |
+  A Helm chart for deploying a Flux instance managed by Flux Operator.
+home: https://github.com/controlplaneio-fluxcd
+icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
+sources:
+  - https://github.com/controlplaneio-fluxcd/flux-operator
+  - https://github.com/controlplaneio-fluxcd/charts
+annotations:
+  "artifacthub.io/license": AGPL-3.0
+  "artifacthub.io/links": |
+    - name: Documentation
+      url: https://fluxcd.control-plane.io/operator
+    - name: Chart Source
+      url: https://github.com/controlplaneio-fluxcd/charts
+    - name: Upstream Project
+      url: https://github.com/controlplaneio-fluxcd/flux-operator
+maintainers:
+  - name: Stefan Prodan
+    email: stefan.prodan@control-plane.io
+keywords:
+  - flux
+  - fluxcd
+  - gitops

--- a/charts/flux-instance/README.md
+++ b/charts/flux-instance/README.md
@@ -1,0 +1,51 @@
+# flux-instance
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.1](https://img.shields.io/badge/AppVersion-v0.0.1-informational?style=flat-square)
+
+This chart is a thin wrapper around the `FluxInstance` custom resource, which is
+used by the [Flux Operator](https://github.com/controlplaneio-fluxcd)
+to install, configure and automatically upgrade Flux.
+
+## Prerequisites
+
+- Kubernetes 1.22+
+- Helm 3.8+
+
+## Installing the Chart
+
+To deploy Flux in the `flux-system` namespace:
+
+```console
+helm -n flux-system install flux oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+```
+
+For more information on the available configuration options,
+see the [Flux Instance documentation](https://fluxcd.control-plane.io/operator/fluxinstance/).
+
+## Uninstalling the Chart
+
+To uninstall Flux without affecting the resources it manages:
+
+```console
+helm -n flux-system uninstall flux
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
+| commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
+| fullnameOverride | string | `"flux"` |  |
+| instance.cluster | object | `{"domain":"cluster.local","multitenant":false,"networkPolicy":true,"type":"kubernetes"}` | Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration |
+| instance.components | list | `["source-controller","kustomize-controller","helm-controller","notification-controller"]` | Components https://fluxcd.control-plane.io/operator/fluxinstance/#components-configuration |
+| instance.distribution | object | `{"artifact":"oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest","imagePullSecret":"","registry":"ghcr.io/fluxcd","version":"2.x"}` | Distribution https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-configuration |
+| instance.kustomize.patches | list | `[{"patch":"- op: add\n  path: /spec/template/spec/containers/0/args/-\n  value: --concurrent=10\n- op: add\n  path: /spec/template/spec/containers/0/args/-\n  value: --requeue-dependency=10s\n","target":{"kind":"Deployment","name":"(kustomize-controller|helm-controller)"}}]` | Patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches |
+| instance.storage | object | `{"class":"","size":""}` | Storage https://fluxcd.control-plane.io/operator/fluxinstance/#storage-configuration |
+| instance.sync | object | `{"kind":"GitRepository","path":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
+| nameOverride | string | `""` |  |
+
+## Source Code
+
+* <https://github.com/controlplaneio-fluxcd/flux-operator>
+* <https://github.com/controlplaneio-fluxcd/charts>

--- a/charts/flux-instance/helmdocs.gotmpl
+++ b/charts/flux-instance/helmdocs.gotmpl
@@ -1,0 +1,34 @@
+{{ template "chart.header" . }}
+{{ template "chart.badgesSection" . }}
+
+This chart is a thin wrapper around the `FluxInstance` custom resource, which is
+used by the [Flux Operator](https://github.com/controlplaneio-fluxcd)
+to install, configure and automatically upgrade Flux.
+
+## Prerequisites
+
+- Kubernetes 1.22+
+- Helm 3.8+
+
+## Installing the Chart
+
+To deploy Flux in the `flux-system` namespace:
+
+```console
+helm -n flux-system install flux oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+```
+
+For more information on the available configuration options,
+see the [Flux Instance documentation](https://fluxcd.control-plane.io/operator/fluxinstance/).
+
+## Uninstalling the Chart
+
+To uninstall Flux without affecting the resources it manages:
+
+```console
+helm -n flux-system uninstall flux
+```
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "chart.sourcesSection" . }}

--- a/charts/flux-instance/templates/NOTES.txt
+++ b/charts/flux-instance/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Documentation at https://fluxcd.control-plane.io/operator/

--- a/charts/flux-instance/templates/_helpers.tpl
+++ b/charts/flux-instance/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "flux-instance.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "flux-instance.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "flux-instance.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "flux-instance.labels" -}}
+helm.sh/chart: {{ include "flux-instance.chart" . }}
+{{ include "flux-instance.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "flux-instance.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "flux-instance.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/flux-instance/templates/instance.yaml
+++ b/charts/flux-instance/templates/instance.yaml
@@ -1,0 +1,38 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: {{ include "flux-instance.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flux-instance.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  distribution:
+    version: {{ .Values.instance.distribution.version }}
+    registry: {{ .Values.instance.distribution.registry }}
+    artifact: {{ .Values.instance.distribution.artifact }}
+    {{- if .Values.instance.distribution.imagePullSecret }}
+    imagePullSecret: {{ .Values.instance.distribution.imagePullSecret }}
+    {{- end }}
+  components: {{ .Values.instance.components | toYaml | nindent 4 }}
+  cluster: {{ .Values.instance.cluster | toYaml | nindent 4 }}
+  kustomize: {{ .Values.instance.kustomize | toYaml | nindent 4 }}
+  {{- if .Values.instance.sync.url }}
+  sync:
+    kind: {{ .Values.instance.sync.kind }}
+    url: {{ .Values.instance.sync.url }}
+    ref: {{ .Values.instance.sync.ref }}
+    path: {{ .Values.instance.sync.path }}
+    {{- if .Values.instance.sync.pullSecret }}
+    pullSecret: {{ .Values.instance.sync.pullSecret }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.instance.storage.size }}
+  storage: {{ .Values.instance.storage | toYaml | nindent 4 }}
+  {{- end }}

--- a/charts/flux-instance/values.schema.json
+++ b/charts/flux-instance/values.schema.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "commonAnnotations": {
+            "properties": {},
+            "type": "object"
+        },
+        "commonLabels": {
+            "properties": {},
+            "type": "object"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "instance": {
+            "properties": {
+                "cluster": {
+                    "properties": {
+                        "domain": {
+                            "type": "string"
+                        },
+                        "multitenant": {
+                            "type": "boolean"
+                        },
+                        "networkPolicy": {
+                            "type": "boolean"
+                        },
+                        "type": {
+                            "enum": [
+                                "kubernetes",
+                                "openshift",
+                                "aws",
+                                "azure",
+                                "gcp"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "multitenant",
+                        "networkPolicy",
+                        "domain"
+                    ],
+                    "type": "object"
+                },
+                "components": {
+                    "items": {
+                        "enum": [
+                            "source-controller",
+                            "kustomize-controller",
+                            "helm-controller",
+                            "notification-controller",
+                            "image-reflector-controller",
+                            "image-automation-controller"
+                        ],
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "distribution": {
+                    "properties": {
+                        "artifact": {
+                            "type": "string"
+                        },
+                        "imagePullSecret": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "version",
+                        "registry"
+                    ],
+                    "type": "object"
+                },
+                "kustomize": {
+                    "properties": {
+                        "patches": {
+                            "items": {
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "storage": {
+                    "properties": {
+                        "class": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "sync": {
+                    "properties": {
+                        "kind": {
+                            "enum": [
+                                "GitRepository",
+                                "OCIRepository",
+                                "Bucket"
+                            ],
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "pullSecret": {
+                            "type": "string"
+                        },
+                        "ref": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "distribution",
+                "cluster"
+            ],
+            "type": "object"
+        },
+        "nameOverride": {
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/charts/flux-instance/values.yaml
+++ b/charts/flux-instance/values.yaml
@@ -1,0 +1,54 @@
+# Default values for flux-instance.
+
+nameOverride: ""
+fullnameOverride: "flux"
+
+instance:
+  # -- Distribution https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-configuration
+  distribution: # @schema required: true
+    version: "2.x" # @schema required: true
+    registry: "ghcr.io/fluxcd" # @schema required: true
+    artifact: "oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest"
+    imagePullSecret: ""
+  # -- Components https://fluxcd.control-plane.io/operator/fluxinstance/#components-configuration
+  components: # @schema item: string; uniqueItems: true; itemEnum: [source-controller,kustomize-controller,helm-controller,notification-controller,image-reflector-controller,image-automation-controller]
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+  # -- Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration
+  cluster: # @schema required: true
+    type: kubernetes # @schema enum:[kubernetes,openshift,aws,azure,gcp]
+    multitenant: false # @schema required: true
+    networkPolicy: true # @schema required: true
+    domain: "cluster.local" # @schema required: true
+  # -- Storage https://fluxcd.control-plane.io/operator/fluxinstance/#storage-configuration
+  storage: # @schema required: false
+    class: ""
+    size: ""
+  # -- Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration
+  sync: # @schema required: false
+    kind: "GitRepository" # @schema enum:[GitRepository,OCIRepository,Bucket]
+    url: ""
+    ref: ""
+    path: ""
+    pullSecret: ""
+  kustomize: # @schema required: false
+    # -- Patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches
+    patches: # @schema item: object
+      - target:
+          kind: Deployment
+          name: "(kustomize-controller|helm-controller)"
+        patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --concurrent=10
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --requeue-dependency=10s
+
+# -- Common annotations to add to all deployed objects including pods.
+commonAnnotations: { }
+
+# -- Common labels to add to all deployed objects including pods.
+commonLabels: { }

--- a/scripts/flux-operator.sh
+++ b/scripts/flux-operator.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
 CHART_DIR="${REPOSITORY_ROOT}/charts/flux-operator"
+INSTANCE_CHART_DIR="${REPOSITORY_ROOT}/charts/flux-instance"
 CRD_URL="https://github.com/controlplaneio-fluxcd/flux-operator/config/crd"
 VERSION=$(gh release view --repo controlplaneio-fluxcd/flux-operator --json tagName -q '.tagName')
 
@@ -76,7 +77,9 @@ info "CRDs generated for Flux Operator ${VERSION}"
 # Patch app version
 export APP_VERSION=${VERSION}
 yq eval '.appVersion=env(APP_VERSION)' -i "${CHART_DIR}/Chart.yaml"
+yq eval '.appVersion=env(APP_VERSION)' -i "${INSTANCE_CHART_DIR}/Chart.yaml"
 export CHART_VERSION=${VERSION#v}
 yq eval '.version=env(CHART_VERSION)' -i "${CHART_DIR}/Chart.yaml"
+yq eval '.version=env(CHART_VERSION)' -i "${INSTANCE_CHART_DIR}/Chart.yaml"
 
 info "Chart.yaml updated to version ${CHART_VERSION}"


### PR DESCRIPTION
This chart is a thin wrapper around the `FluxInstance` custom resource, which is used by the [Flux Operator](https://github.com/controlplaneio-fluxcd) to install, configure and automatically upgrade Flux.

This chart is needed when deploying Flux with Terraform, xref: https://github.com/controlplaneio-fluxcd/flux-operator/pull/58