### PR TITLE
Add labels config for service monitor

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -49,7 +49,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
-| serviceMonitor | object | `{"create":false,"interval":"60s","scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |
+| serviceMonitor | object | `{"create":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |
 | tolerations | list | `[]` | Pod tolerations settings. |
 
 ## Source Code

--- a/charts/flux-operator/templates/servicemonitor.yaml
+++ b/charts/flux-operator/templates/servicemonitor.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -306,6 +306,10 @@
                 "interval": {
                     "type": "string"
                 },
+                "labels": {
+                    "properties": {},
+                    "type": "object"
+                },
                 "scrapeTimeout": {
                     "type": "string"
                 }

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -95,6 +95,7 @@ serviceMonitor: # @schema default: {"create":false,"interval":"60s","scrapeTimeo
   create: false
   interval: 60s
   scrapeTimeout: 30s
+  labels: { }
 
 # -- Marketplace settings.
 marketplace:


### PR DESCRIPTION
This PR allows users to set the labels on the generated ServiceMonitor. When using `kube-prometheus-stack` the ServiceMonitor objects must be labeled with `release: kube-prometheus-stack`. 

xref: https://github.com/prometheus-operator/kube-prometheus/issues/1392#issuecomment-1411719953