### PR TITLE
make ClusterRole configurable

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -32,6 +32,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| clusterRole | string | `"cluster-admin"` | ClusterRole to bind in the ClusterRoleBinding. Can be overridden to use a different role. |
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}` | Pod affinity and anti-affinity settings. |
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |

--- a/charts/flux-operator/templates/clusterrole.yaml
+++ b/charts/flux-operator/templates/clusterrole.yaml
@@ -14,7 +14,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Values.clusterRole | default "cluster-admin" }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "flux-operator.fullname" . }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -1,6 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
+        "clusterRole": {
+            "description": "ClusterRole to bind in the ClusterRoleBinding. Defaults to 'cluster-admin', but can be overridden.",
+            "type": "string",
+            "default": "cluster-admin"
+        },
         "affinity": {
             "default": {
                 "nodeAffinity": {

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -108,3 +108,8 @@ marketplace:
   type: ""
   license: ""
   account: ""
+
+
+# -- ClusterRole to bind in the ClusterRoleBinding.
+# -- Default is "cluster-admin", but users can override this to use a different role.
+# clusterRole: "cluster-admin"


### PR DESCRIPTION
This PR enhances the Helm chart by making the ClusterRoleBinding role configurable. Previously, the role was hardcoded to `cluster-admin`:

- A new clusterRole value is introduced in values.yaml, defaulting to "cluster-admin".
- Users can now override the ClusterRole via values.yaml or Helm --set flag.
- If no value is provided, it falls back to cluster-admin, maintaining existing behavior.