### PR TITLE
Add `multitenancy` option to flux-operator

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -44,6 +44,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |
 | logLevel | string | `"info"` | Container logging level flag. |
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
+| multitenancy | object | `{"defaultServiceAccount":"flux-operator","enabled":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
 | nameOverride | string | `""` |  |
 | podSecurityContext | object | `{}` | Pod security context settings. |
 | priorityClassName | string | `""` | Pod priority class name. Recommended value is system-cluster-critical. |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         - name: manager
           args:
             - --log-level={{ .Values.logLevel }}
+            {{- if .Values.multitenancy.enabled }}
+            - --default-service-account={{ .Values.multitenancy.defaultServiceAccount }}
+            {{- end }}
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -169,6 +169,20 @@
             },
             "type": "object"
         },
+        "multitenancy": {
+            "properties": {
+                "defaultServiceAccount": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "defaultServiceAccount"
+            ],
+            "type": "object"
+        },
         "nameOverride": {
             "type": "string"
         },

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -3,6 +3,11 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs.
+multitenancy:
+  enabled: false
+  defaultServiceAccount: "flux-operator" # @schema required: true
+
 # -- Install and upgrade the custom resource definitions.
 installCRDs: true # @schema default: true
 


### PR DESCRIPTION
Allow enabling [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs.