### PR TITLE
Add `rbac` options to flux-operator

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -48,6 +48,8 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | nameOverride | string | `""` |  |
 | podSecurityContext | object | `{}` | Pod security context settings. |
 | priorityClassName | string | `""` | Pod priority class name. Recommended value is system-cluster-critical. |
+| rbac.create | bool | `true` | Grant the cluster-admin role to the flux-operator service account (required for the Flux Instance deployment). |
+| rbac.createAggregation | bool | `true` | Grant the Kubernetes view, edit and admin roles access to ResourceSet APIs. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | Container readiness probe settings. |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |

--- a/charts/flux-operator/templates/admin-clusterrole.yaml
+++ b/charts/flux-operator/templates/admin-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -19,3 +20,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "flux-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/flux-operator/templates/aggregate-clusterrole.yaml
+++ b/charts/flux-operator/templates/aggregate-clusterrole.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.rbac.createAggregation }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "flux-operator.fullname" . }}-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- include "flux-operator.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+    resources:
+      - resourcesets
+      - resourcesetinputproviders
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "flux-operator.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "flux-operator.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+    resources:
+      - resourcesets
+      - resourcesetinputproviders
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -197,6 +197,17 @@
             "default": "system-cluster-critical",
             "type": "string"
         },
+        "rbac": {
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "createAggregation": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "readinessProbe": {
             "default": {
                 "httpGet": {

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -60,6 +60,12 @@ serviceAccount: # @schema default: {"create":true,"automount":true,"name":""}
   automount: true
   name: ""
 
+rbac:
+   # -- Grant the cluster-admin role to the flux-operator service account (required for the Flux Instance deployment).
+  create: true
+  # -- Grant the Kubernetes view, edit and admin roles access to ResourceSet APIs.
+  createAggregation: true
+
 # -- Pod security context settings.
 podSecurityContext: { } # @schema default: {"fsGroup":1337}
 


### PR DESCRIPTION
Allow disabling the ClusterRoleBinding to `cluster-admin` for users that would like to create their own roles and bindings for the `flux-operator` service account. Closes #46

Add aggregated roles for Kubernetes `view`, `edit` and `admin` of ResourceSet APIs with the option to disabled them.