### PR TITLE
make flux-operator manager container imagePullPolicy to be configurable

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -39,7 +39,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | extraEnvs | list | `[]` | Container extra environment variables. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | If `true`, the container ports (`8080` and `8081`) are exposed on the host network. |
-| image | object | `{"pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |
+| image | object | `{"imagePullPolicy":"IfNotPresent","pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |
 | installCRDs | bool | `true` | Install and upgrade the custom resource definitions. |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |
 | logLevel | string | `"info"` | Container logging level flag. |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
           ports:
             - name: http-metrics
               containerPort: 8080

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -23,7 +23,7 @@ image:
   repository: ghcr.io/controlplaneio-fluxcd/flux-operator # @schema required: true
   tag: ""
   pullSecrets: [ ] # @schema item: object ; uniqueItems: true
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent # @schema enum:[IfNotPresent, Always, Never]
 
 # -- Pod priority class name.
 # Recommended value is system-cluster-critical.

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -23,6 +23,7 @@ image:
   repository: ghcr.io/controlplaneio-fluxcd/flux-operator # @schema required: true
   tag: ""
   pullSecrets: [ ] # @schema item: object ; uniqueItems: true
+  imagePullPolicy: IfNotPresent
 
 # -- Pod priority class name.
 # Recommended value is system-cluster-critical.


### PR DESCRIPTION
Make flux-operator manager container imagePullPolicy to be configurable.

The reason is that our organization has Gatekeeper enforced in the clusters, one of the violation is that:
Container 'manager' must either use an image digest or set 'imagePullPolicy: Always'

Currently, the imagePullPolicy for flux-operator manager container is hard coded to be 'IfNotPresent'