### PR TITLE
Added node selector field for flux operator

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -46,6 +46,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
 | multitenancy | object | `{"defaultServiceAccount":"flux-operator","enabled":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
 | nameOverride | string | `""` |  |
+| nodeSelectors | list | `[]` | Pod Node Selector settings. |
 | podSecurityContext | object | `{}` | Pod security context settings. |
 | priorityClassName | string | `""` | Pod priority class name. Recommended value is system-cluster-critical. |
 | rbac.create | bool | `true` | Grant the cluster-admin role to the flux-operator service account (required for the Flux Instance deployment). |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -107,3 +107,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -362,6 +362,13 @@
             },
             "type": "array",
             "uniqueItems": true
+        },
+        "nodeSelector": {
+            "items": {
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
         }
     },
     "required": [

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -96,6 +96,9 @@ affinity: # @schema default: {"nodeAffinity":{"requiredDuringSchedulingIgnoredDu
 # -- Pod tolerations settings.
 tolerations: [ ] # @schema item: object ; uniqueItems: true
 
+# -- Pod Node Selector settings.
+nodeSelectors: [ ] # @schema item: object ; uniqueItems: true
+
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false
 


### PR DESCRIPTION
In our org, the value of node selector field has to be selected from a fixed values for compliance purpose. 
So we need this to be configurable for flux-operator.