### PR TITLE
Add charts-syncer action

### DIFF
--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -1,10 +1,9 @@
 name: vendor
 
 on:
-  pull_request:
-  push:
-    branches:
-      - 'main'
+  workflow_dispatch:
+  schedule:
+    - cron: '00 4 * * 1-5'
 
 jobs:
   charts-syncer:

--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Setup charts-syncer
         uses: ./actions/charts-syncer
-      - name: Sync metrics-server chart
+      - name: Sync charts
         env:
           TARGET_REPO_AUTH_USERNAME: ${{ github.actor }}
           TARGET_REPO_AUTH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -25,3 +25,4 @@ jobs:
           TARGET_CONTAINERS_AUTH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           charts-syncer sync --latest-version-only --config=sync/metrics-server.yaml
+          charts-syncer sync --latest-version-only --config=sync/ingress-nginx.yaml

--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -1,0 +1,25 @@
+name: vendor
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  charts-syncer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for reading the configuration.
+      packages: write # for pushing helm chart artifacts.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Setup charts-syncer
+        uses: ./actions/charts-syncer
+      - name: Print version
+        env:
+          TARGET_CONTAINERS_AUTH_USERNAME: ${{ github.actor }}
+          TARGET_CONTAINERS_AUTH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          charts-syncer version

--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -17,9 +17,11 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Setup charts-syncer
         uses: ./actions/charts-syncer
-      - name: Print version
+      - name: Sync metrics-server chart
         env:
+          TARGET_REPO_AUTH_USERNAME: ${{ github.actor }}
+          TARGET_REPO_AUTH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_CONTAINERS_AUTH_USERNAME: ${{ github.actor }}
           TARGET_CONTAINERS_AUTH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          charts-syncer version
+          charts-syncer sync --latest-version-only --config=sync/metrics-server.yaml

--- a/.github/workflows/vendor.yaml
+++ b/.github/workflows/vendor.yaml
@@ -26,3 +26,4 @@ jobs:
         run: |
           charts-syncer sync --latest-version-only --config=sync/metrics-server.yaml
           charts-syncer sync --latest-version-only --config=sync/ingress-nginx.yaml
+          charts-syncer sync --latest-version-only --config=sync/external-dns.yaml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 This repository contains the Helm charts for the ControlPlane Flux CD projects.
 
-## Charts
+## Flux Charts
 
 - [flux-operator](charts/flux-operator/README.md)
 - [flux-instance](charts/flux-instance/README.md)
+
+## Vendored Charts
+
+- `ghcr.io/controlplaneio-fluxcd/charts/metrics-server`
+- `ghcr.io/controlplaneio-fluxcd/charts/external-dns`
+- `ghcr.io/controlplaneio-fluxcd/charts/ingress-nginx`
+
+The vendored charts are [synced](.github/workflows/vendor.yaml) from
+the upstream Kubernetes HTTP/S Helm repositories on a daily basis.

--- a/actions/charts-syncer/action.yml
+++ b/actions/charts-syncer/action.yml
@@ -1,0 +1,78 @@
+name: Setup Bitnami charts-syncer
+description: A GitHub Action for running Bitnami charts-syncer commands
+author: Stefan Prodan
+branding:
+  color: blue
+  icon: command
+inputs:
+  version:
+    description: "Bitnami charts-syncer version e.g. v2.1.0 (defaults to latest stable release)"
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Download the binary to the runner's cache dir
+      shell: bash
+      run: |
+        VERSION=${{ inputs.version }}
+        if [[ -z "$VERSION" ]] || [[ "$VERSION" == "latest" ]]; then
+          VERSION=$(curl -fsSL -H "Authorization: token ${{github.token}}" https://api.github.com/repos/bitnami/charts-syncer/releases/latest | grep tag_name | cut -d '"' -f 4)
+        fi
+        if [[ -z "$VERSION" ]]; then
+          echo "Unable to determine charts-syncer version"
+          exit 1
+        fi
+        if [[ $VERSION = v* ]]; then
+          VERSION="${VERSION:1}"
+        fi
+
+        OS=$(echo "${RUNNER_OS}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$OS" == "macos" ]]; then
+          OS="darwin"
+        fi
+
+        ARCH=$(echo "${RUNNER_ARCH}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$ARCH" == "x64" ]]; then
+          ARCH="x86_64"
+        fi
+        
+        CLI_EXEC_FILE="charts-syncer"
+        if [[ "$OS" == "windows" ]]; then
+            CLI_EXEC_FILE="${CLI_EXEC_FILE}.exe"
+        fi
+
+        CLI_TOOL_DIR="${RUNNER_TOOL_CACHE}/charts-syncer/${VERSION}/${OS}/${ARCH}"
+        if [[ ! -x "$CLI_TOOL_DIR/$CLI_EXEC_FILE" ]]; then
+          DL_DIR="$(mktemp -dt charts-syncer-XXXXXX)"
+          trap "rm -rf $DL_DIR" EXIT
+
+          echo "Downloading charts-syncer ${VERSION} for ${OS}/${ARCH}"
+          CLI_TARGET_FILE="charts-syncer_${VERSION}_${OS}_${ARCH}.tar.gz"
+          CLI_CHECKSUMS_FILE="checksums.txt"
+
+          CLI_DOWNLOAD_URL="https://github.com/bitnami/charts-syncer/releases/download/v${VERSION}/"
+
+          curl -fsSL -o "$DL_DIR/$CLI_TARGET_FILE" "$CLI_DOWNLOAD_URL/$CLI_TARGET_FILE"
+          curl -fsSL -o "$DL_DIR/$CLI_CHECKSUMS_FILE" "$CLI_DOWNLOAD_URL/$CLI_CHECKSUMS_FILE"
+
+          echo "Verifying checksum"
+          sum=$(openssl sha1 -sha256 "$DL_DIR/$CLI_TARGET_FILE" | awk '{print $2}')
+          expected_sum=$(grep "$CLI_TARGET_FILE" "$DL_DIR/$CLI_CHECKSUMS_FILE" | awk '{print $1}')
+          if [ "$sum" != "$expected_sum" ]; then
+            echo "SHA sum of ${CLI_TARGET_FILE} does not match. Aborting."
+            exit 1
+          fi
+
+          echo "Installing charts-syncer to ${CLI_TOOL_DIR}"
+          mkdir -p "$CLI_TOOL_DIR"
+          tar xzf "$DL_DIR/$CLI_TARGET_FILE" -C "$CLI_TOOL_DIR" $CLI_EXEC_FILE
+          chmod +x "$CLI_TOOL_DIR/$CLI_EXEC_FILE"
+        fi
+
+        echo "Adding charts-syncer to path"
+        echo "$CLI_TOOL_DIR" >> "$GITHUB_PATH"
+
+    - name: "Print the version"
+      shell: bash
+      run: |
+        charts-syncer version

--- a/sync/external-dns.yaml
+++ b/sync/external-dns.yaml
@@ -1,0 +1,12 @@
+charts:
+  - external-dns
+source:
+  repo:
+    kind: HELM
+    url: https://kubernetes-sigs.github.io/external-dns
+target:
+  repo:
+    kind: OCI
+    url: https://ghcr.io/controlplaneio-fluxcd/charts
+skipImages: true
+skipArtifacts: true

--- a/sync/ingress-nginx.yaml
+++ b/sync/ingress-nginx.yaml
@@ -1,0 +1,12 @@
+charts:
+  - ingress-nginx
+source:
+  repo:
+    kind: HELM
+    url: https://kubernetes.github.io/ingress-nginx
+target:
+  repo:
+    kind: OCI
+    url: https://ghcr.io/controlplaneio-fluxcd/charts
+skipImages: true
+skipArtifacts: true

--- a/sync/metrics-server.yaml
+++ b/sync/metrics-server.yaml
@@ -1,0 +1,12 @@
+charts:
+  - metrics-server
+source:
+  repo:
+    kind: HELM
+    url: https://kubernetes-sigs.github.io/metrics-server
+target:
+  repo:
+    kind: OCI
+    url: https://ghcr.io/controlplaneio-fluxcd/charts
+skipImages: true
+skipArtifacts: true


### PR DESCRIPTION
Sync Helm charts from Kubernetes HTTP/S Helm repos to GitHub Container Registry:

- `ghcr.io/controlplaneio-fluxcd/charts/metrics-server`
- `ghcr.io/controlplaneio-fluxcd/charts/external-dns`
- `ghcr.io/controlplaneio-fluxcd/charts/ingress-nginx`

This is required to replace the Bitnami OCI charts and images with the official ones published by the Kubernetes SIGs.