### PR TITLE
flux-operator: Add Kubernetes API priority settings

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -33,6 +33,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}` | Pod affinity and anti-affinity settings. |
+| apiPriority | object | `{"enabled":false,"extraServiceAccounts":[],"level":"workload-high"}` | Kubernetes [API priority and fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) settings. |
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | extraArgs | list | `[]` | Container extra arguments. |

--- a/charts/flux-operator/templates/flowschema.yaml
+++ b/charts/flux-operator/templates/flowschema.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.apiPriority.enabled }}
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: {{ include "flux-operator.fullname" . }}
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "false"
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 950
+  priorityLevelConfiguration:
+    name: {{ .Values.apiPriority.level }}
+  rules:
+    - nonResourceRules:
+        - nonResourceURLs:
+            - '*'
+          verbs:
+            - '*'
+      resourceRules:
+        - apiGroups:
+            - '*'
+          clusterScope: true
+          namespaces:
+            - '*'
+          resources:
+            - '*'
+          verbs:
+            - '*'
+      subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: {{ include "flux-operator.serviceAccountName" . }}
+            namespace: {{ .Release.Namespace }}
+        {{- range .Values.apiPriority.extraServiceAccounts }}
+        - kind: ServiceAccount
+          serviceAccount:
+            name: {{ .name }}
+            namespace: {{ .namespace }}
+        {{- end }}
+{{- end }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -63,6 +63,25 @@
             },
             "type": "object"
         },
+        "apiPriority": {
+            "default": {
+                "enabled": false,
+                "extraServiceAccounts": [],
+                "level": "workload-high"
+            },
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraServiceAccounts": {
+                    "type": "array"
+                },
+                "level": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "commonAnnotations": {
             "properties": {},
             "type": "object"

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -33,6 +33,16 @@ image:
 # Recommended value is system-cluster-critical.
 priorityClassName: "" # @schema default: "system-cluster-critical"
 
+# -- Kubernetes [API priority and fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) settings.
+apiPriority: # @schema default: {"enabled":false,"level":"workload-high","extraServiceAccounts":[]}
+  enabled: false
+  level: workload-high
+  extraServiceAccounts: []
+#    - name: kustomize-controller
+#      namespace: flux-system
+#    - name: helm-controller
+#      namespace: flux-system
+
 # -- Container resources requests and limits settings.
 resources: # @schema required: true
   limits:


### PR DESCRIPTION
Allow setting Kubernetes API priority level for Flux Operator and the Flux controllers to avoid rate limits.