### PR TITLE
fix(flux-operator): invalid ClusterRoleBinding with custom SA name

### DIFF
--- a/charts/flux-operator/templates/admin-clusterrole.yaml
+++ b/charts/flux-operator/templates/admin-clusterrole.yaml
@@ -18,6 +18,6 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-operator.fullname" . }}
+    name: {{ include "flux-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
This commit ensures that the right ServiceAccount name is referenced when the flux-operator chart is deployed and a custom value is passed for .serviceAccount.name