### PR TITLE
flux-instance: add pull-secret template

### DIFF
--- a/charts/flux-instance/README.md
+++ b/charts/flux-instance/README.md
@@ -44,7 +44,8 @@ helm -n flux-system uninstall flux
 | instance.kustomize.patches | list | `[]` | Kustomize patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches |
 | instance.sharding | object | `{"key":"sharding.fluxcd.io/key","shards":[]}` | Sharding https://fluxcd.control-plane.io/operator/fluxinstance/#sharding-configuration |
 | instance.storage | object | `{"class":"","size":""}` | Storage https://fluxcd.control-plane.io/operator/fluxinstance/#storage-configuration |
-| instance.sync | object | `{"interval":"1m","kind":"GitRepository","name":"","path":"","provider":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
+| instance.sync | object | `{"interval":"1m","kind":"GitRepository","name":"","path":"","provider":"","pullSecret":"","pullSecretStringData":{},"ref":"","url":""}` | Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration |
+| instance.sync.pullSecretStringData | object | `{}` | Creates secret and sets it as pullSecret |
 | nameOverride | string | `""` |  |
 
 ## Source Code

--- a/charts/flux-instance/templates/instance.yaml
+++ b/charts/flux-instance/templates/instance.yaml
@@ -50,7 +50,9 @@ spec:
     {{- if .Values.instance.sync.provider }}
     provider: {{ .Values.instance.sync.provider }}
     {{- end }}
-    {{- if .Values.instance.sync.pullSecret }}
+    {{- if .Values.instance.sync.pullSecretStringData }}
+    pullSecret: {{ include "flux-instance.fullname" . }}-pull
+    {{- else if .Values.instance.sync.pullSecret }}
     pullSecret: {{ .Values.instance.sync.pullSecret }}
     {{- end }}
   {{- end }}

--- a/charts/flux-instance/templates/pullsecret.yaml
+++ b/charts/flux-instance/templates/pullsecret.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.instance.sync.pullSecretStringData }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "flux-instance.fullname" . }}-pull
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flux-instance.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+stringData:
+  {{- toYaml .Values.instance.sync.pullSecretStringData | nindent 2 }}
+{{ end }}

--- a/charts/flux-instance/values.schema.json
+++ b/charts/flux-instance/values.schema.json
@@ -154,6 +154,10 @@
                         "pullSecret": {
                             "type": "string"
                         },
+                        "pullSecretStringData": {
+                            "properties": {},
+                            "type": "object"
+                        },
                         "ref": {
                             "type": "string"
                         },

--- a/charts/flux-instance/values.yaml
+++ b/charts/flux-instance/values.yaml
@@ -44,6 +44,8 @@ instance:
     ref: ""
     path: ""
     pullSecret: ""
+    # -- Creates secret and sets it as pullSecret
+    pullSecretStringData: { }
     name: ""
     provider: ""
   kustomize: # @schema required: false


### PR DESCRIPTION
Convencience template, so when using this helmchart you can use the same
helm release to create the pullSecret instead of having to use another
way to create the secret.

Example:

```yaml
  sync:
    pullSecret: ""
    pullSecretStringData:
      username: user
      password: password
```