### PR TITLE
fix: name of the FluxInstance has to be "flux"

### DIFF
--- a/charts/flux-instance/templates/instance.yaml
+++ b/charts/flux-instance/templates/instance.yaml
@@ -1,7 +1,7 @@
 apiVersion: fluxcd.controlplane.io/v1
 kind: FluxInstance
 metadata:
-  name: {{ include "flux-instance.fullname" . }}
+  name: flux
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flux-instance.labels" . | nindent 4 }}


### PR DESCRIPTION
flux-operator only accept "flux" as the metadata name of `FluxInstance`