### PR TITLE
Add support for extra volumes and volume mounts in Flux Operator

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -38,6 +38,8 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | extraArgs | list | `[]` | Container extra arguments. |
 | extraEnvs | list | `[]` | Container extra environment variables. |
+| extraVolumeMounts | list | `[]` | Container extra volume mounts. |
+| extraVolumes | list | `[]` | Pod extra volumes. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | If `true`, the container ports (`8080` and `8081`) are exposed on the host network. |
 | image | object | `{"imagePullPolicy":"IfNotPresent","pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -98,9 +98,15 @@ spec:
           volumeMounts:
             - name: temp
               mountPath: /tmp
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: temp
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+          {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -116,11 +116,17 @@ nodeSelector: { } # @schema type: object
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false
 
+# -- Pod extra volumes.
+extraVolumes: [ ] # @schema item: object ; uniqueItems: true
+
 # -- Container extra environment variables.
 extraEnvs: [ ] # @schema item: object ; uniqueItems: true
 
 # -- Container extra arguments.
 extraArgs: [ ] # @schema item: string ; uniqueItems: true
+
+# -- Container extra volume mounts.
+extraVolumeMounts: [ ] # @schema item: object ; uniqueItems: true
 
 # -- Container logging level flag.
 logLevel: "info" # @schema enum:[debug,info,error]


### PR DESCRIPTION
This is required for supporting cross-cloud controller-level workload identity (same-cloud already works via `commonAnnotations` and `commonLabels`):

* https://fluxcd.io/flux/integrations/aws/#at-the-controller-level
* https://fluxcd.io/flux/integrations/azure/#at-the-controller-level
* https://fluxcd.io/flux/integrations/gcp/#at-the-controller-level