### PR TITLE
Introduce http transport for mcp and workload identity lockdown for operator

### DIFF
--- a/charts/flux-operator-mcp/README.md
+++ b/charts/flux-operator-mcp/README.md
@@ -44,14 +44,30 @@ Add the following configuration to your AI assistant to connect to the MCP Serve
 
 ```json
 {
- "mcp": {
-   "servers": {
-     "flux-operator-mcp": {
-       "type": "sse",
-       "url": "http://localhost:9090/sse"
-     }
-   }
- }
+  "mcp": {
+    "servers": {
+      "flux-operator-mcp": {
+        "type": "sse",
+        "url": "http://localhost:9090/sse"
+      }
+    }
+  }
+}
+```
+
+For the streamable HTTP transport, set the Helm value `transport` to `http`
+(defaults to `sse`) and use the following AI assistant configuration:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "flux-operator-mcp": {
+        "type": "http",
+        "url": "http://localhost:9090/mcp"
+      }
+    }
+  }
 }
 ```
 
@@ -69,6 +85,7 @@ For more information, please refer to the [Flux MCP Server documentation](https:
 | extraEnvs | list | `[]` | Container extra environment variables. |
 | fullnameOverride | string | `""` |  |
 | image | object | `{"imagePullPolicy":"IfNotPresent","pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator-mcp","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[],"tls":[]}` | Ingress settings. |
 | livenessProbe | object | `{"tcpSocket":{"port":"http"}}` | Container liveness probe settings. |
 | nameOverride | string | `""` |  |
 | networkPolicy | object | `{"create":true,"ingress":{"namespaces":[]}}` | Network policy settings. |
@@ -82,6 +99,7 @@ For more information, please refer to the [Flux MCP Server documentation](https:
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
 | tolerations | list | `[]` | Pod tolerations settings. |
+| transport | string | `"sse"` | MCP server transport. Either 'sse' for server-sent events, or 'http' for streamable HTTP. |
 
 ## Source Code
 

--- a/charts/flux-operator-mcp/helmdocs.gotmpl
+++ b/charts/flux-operator-mcp/helmdocs.gotmpl
@@ -43,14 +43,30 @@ Add the following configuration to your AI assistant to connect to the MCP Serve
 
 ```json
 {
- "mcp": {
-   "servers": {
-     "flux-operator-mcp": {
-       "type": "sse",
-       "url": "http://localhost:9090/sse"
-     }
-   }
- }
+  "mcp": {
+    "servers": {
+      "flux-operator-mcp": {
+        "type": "sse",
+        "url": "http://localhost:9090/sse"
+      }
+    }
+  }
+}
+```
+
+For the streamable HTTP transport, set the Helm value `transport` to `http`
+(defaults to `sse`) and use the following AI assistant configuration:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "flux-operator-mcp": {
+        "type": "http",
+        "url": "http://localhost:9090/mcp"
+      }
+    }
+  }
 }
 ```
 

--- a/charts/flux-operator-mcp/templates/deployment.yaml
+++ b/charts/flux-operator-mcp/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         - name: manager
           args:
             - serve
-            - --transport=sse
+            - --transport={{ .Values.transport }}
             - --port=9090
             - --read-only={{ .Values.readonly }}
             {{- range .Values.extraArgs }}

--- a/charts/flux-operator-mcp/templates/ingress.yaml
+++ b/charts/flux-operator-mcp/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "flux-operator-mcp.fullname" . }}
+  labels:
+    {{- include "flux-operator-mcp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "flux-operator-mcp.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/flux-operator-mcp/values.schema.json
+++ b/charts/flux-operator-mcp/values.schema.json
@@ -135,6 +135,40 @@
                 }
             }
         },
+        "ingress": {
+            "default": {
+                "annotations": {},
+                "className": "",
+                "enabled": false
+            },
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "className": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "tls": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
+        },
         "livenessProbe": {
             "type": "object",
             "properties": {
@@ -310,6 +344,13 @@
             "items": {
                 "type": "object"
             }
+        },
+        "transport": {
+            "type": "string",
+            "enum": [
+                "sse",
+                "http"
+            ]
         }
     }
 }

--- a/charts/flux-operator-mcp/values.yaml
+++ b/charts/flux-operator-mcp/values.yaml
@@ -3,6 +3,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# -- MCP server transport. Either 'sse' for server-sent events, or 'http' for streamable HTTP.
+transport: sse # @schema enum:[sse, http]
+
 # -- Run the server in readonly mode by disabling the MCP tools that can modify the cluster state.
 readonly: false # @schema default: false
 
@@ -101,3 +104,19 @@ extraEnvs: [ ] # @schema item: object ; uniqueItems: true
 
 # -- Container extra arguments.
 extraArgs: [ ] # @schema item: string ; uniqueItems: true
+
+# -- Ingress settings.
+ingress: # @schema default: {"enabled":false,"className":"","annotations":{}}
+  enabled: false # @schema default: false
+  className: ""
+  annotations: { } # @schema type: object
+    # nginx.ingress.kubernetes.io/auth-url: "https://$host/authenticate"
+  hosts: [ ] # @schema item: object ; uniqueItems: true
+    # - host: flux-operator-mcp.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: ImplementationSpecific
+  tls: [ ] # @schema item: object ; uniqueItems: true
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -47,7 +47,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |
 | logLevel | string | `"info"` | Container logging level flag. |
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
-| multitenancy | object | `{"defaultServiceAccount":"flux-operator","enabled":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
+| multitenancy | object | `{"defaultServiceAccount":"flux-operator","defaultWorkloadIdentityServiceAccount":"flux-operator","enabled":false,"enabledForWorkloadIdentity":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Pod Node Selector settings. |
 | podSecurityContext | object | `{}` | Pod security context settings. |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             {{- if .Values.multitenancy.enabled }}
             - --default-service-account={{ .Values.multitenancy.defaultServiceAccount }}
             {{- end }}
+            {{- if .Values.multitenancy.enabledForWorkloadIdentity }}
+            - --default-workload-identity-service-account={{ .Values.multitenancy.defaultWorkloadIdentityServiceAccount }}
+            {{- end }}
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -216,13 +216,20 @@
         "multitenancy": {
             "type": "object",
             "required": [
-                "defaultServiceAccount"
+                "defaultServiceAccount",
+                "defaultWorkloadIdentityServiceAccount"
             ],
             "properties": {
                 "defaultServiceAccount": {
                     "type": "string"
                 },
+                "defaultWorkloadIdentityServiceAccount": {
+                    "type": "string"
+                },
                 "enabled": {
+                    "type": "boolean"
+                },
+                "enabledForWorkloadIdentity": {
                     "type": "boolean"
                 }
             }

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -6,7 +6,9 @@ fullnameOverride: ""
 # -- Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs.
 multitenancy:
   enabled: false
+  enabledForWorkloadIdentity: false
   defaultServiceAccount: "flux-operator" # @schema required: true
+  defaultWorkloadIdentityServiceAccount: "flux-operator" # @schema required: true
 
 # -- Flux [reporting](https://fluxcd.control-plane.io/operator/fluxreport/) settings.
 reporting:


### PR DESCRIPTION
Part of: https://github.com/controlplaneio-fluxcd/flux-operator/issues/379