### PR TITLE
mcp: add checksum/config with sha256 of the configmap content

### DIFF
--- a/charts/flux-operator-mcp/templates/deployment.yaml
+++ b/charts/flux-operator-mcp/templates/deployment.yaml
@@ -18,8 +18,13 @@ spec:
       {{- include "flux-operator-mcp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.commonAnnotations }}
+      {{- if or .Values.config.enabled .Values.commonAnnotations }}
       annotations:
+      {{- end }}
+      {{- if .Values.config.enabled }}
+        checksum/config: {{ (include (print $.Template.BasePath "/configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
+      {{- end }}
+      {{- with .Values.commonAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Part of: https://github.com/controlplaneio-fluxcd/flux-operator/pull/424

Add to pods the `checksum/config` annotation with the sha256 of the ConfigMap content to automatically trigger restarts when the config changes.