### PR TITLE
feat(flux-operator): add Gateway API HTTPRoute support

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -80,6 +80,7 @@ see the Flux Operator [documentation](https://fluxoperator.dev/docs/).
 | tolerations | list | `[]` | Pod tolerations settings. |
 | web.config | object | `{}` | The spec of the [Web Config API](https://fluxoperator.dev/docs/web-ui/web-config-api/) |
 | web.enabled | bool | `true` | Enable the [Flux Status web server](https://fluxoperator.dev/web-ui/) on port 9080. |
+| web.httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"parentRefs":[]}` | Gateway API HTTPRoute settings for the Flux Status web interface. |
 | web.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[],"tls":[]}` | Ingress settings for the Flux Status web interface. |
 | web.networkPolicy | object | `{"create":true}` | Create a NetworkPolicy to allow access to the Flux Status web interface. |
 | web.serverOnly | bool | `false` | Run the Flux Status web server as a standalone deployment (requires a dedicated Helm release). |

--- a/charts/flux-operator/templates/httproute.yaml
+++ b/charts/flux-operator/templates/httproute.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.web.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "flux-operator.fullname" . }}
+  labels:
+    {{- include "flux-operator.labels" . | nindent 4 }}
+  {{- with .Values.web.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.web.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.web.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "flux-operator.fullname" . }}
+          port: 9080
+{{- end }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -435,6 +435,38 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "httpRoute": {
+                    "default": {
+                        "annotations": {},
+                        "enabled": false,
+                        "hostnames": [],
+                        "parentRefs": []
+                    },
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "hostnames": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "parentRefs": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
                 "ingress": {
                     "default": {
                         "annotations": {},

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -38,6 +38,16 @@ web:
     #  - secretName: flux-operator-tls
     #    hosts:
     #      - flux-operator.example.com
+  # -- Gateway API HTTPRoute settings for the Flux Status web interface.
+  httpRoute: # @schema default: {"enabled":false,"annotations":{},"parentRefs":[],"hostnames":[]}
+    enabled: false # @schema default: false
+    annotations: { } # @schema type: object
+    parentRefs: [ ] # @schema item: object ; uniqueItems: true
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+    hostnames: [ ] # @schema item: string ; uniqueItems: true
+    # - flux.example.com
 
 # -- Install and upgrade the custom resource definitions.
 installCRDs: true # @schema default: true


### PR DESCRIPTION
## Summary

Add support for Gateway API HTTPRoute as an alternative to Ingress for exposing the Flux Operator web UI.

With [ingress-nginx being deprecated](https://kubernetes.io/blog/2025/06/13/ingress-nginx-project-status-update/) and the Kubernetes community migrating to Gateway API, this provides a native way to expose the web UI using HTTPRoute resources.

I ran into this while setting up the Flux Operator web UI in my homelab cluster which uses Envoy Gateway. Adding HTTPRoute support seemed like a useful contribution given the broader migration away from Ingress.

## Changes

- Added `templates/httproute.yaml` template
- Added `web.httpRoute` configuration in `values.yaml`
- Regenerated `values.schema.json`

## Configuration example

```yaml
web:
  httpRoute:
    enabled: true
    annotations: {}
    parentRefs:
      - name: my-gateway
        namespace: gateway-system
        sectionName: https
    hostnames:
      - flux.example.com
```

## Test

```bash
helm template test . --kube-version 1.30.0 \
  --set web.httpRoute.enabled=true \
  --set 'web.httpRoute.parentRefs[0].name=my-gateway' \
  --set 'web.httpRoute.parentRefs[0].namespace=gateway-system' \
  --set 'web.httpRoute.hostnames[0]=flux.example.com'
```