### PR TITLE
allow setting the IP family policy

### DIFF
--- a/charts/flux-operator-mcp/README.md
+++ b/charts/flux-operator-mcp/README.md
@@ -98,6 +98,7 @@ For more information, please refer to the [Flux MCP Server documentation](https:
 | readonly | bool | `false` | Run the server in readonly mode by disabling the MCP tools that can modify the cluster state. |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
+| service.ipFamilyPolicy | string | `""` | Sets the IP family policy on all Service resources. Uses Kubernetes defaults if unset |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
 | tolerations | list | `[]` | Pod tolerations settings. |
 | transport | string | `"sse"` | MCP server transport. Either 'sse' for server-sent events, or 'http' for streamable HTTP. |

--- a/charts/flux-operator-mcp/templates/service.yaml
+++ b/charts/flux-operator-mcp/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: 9090
       targetPort: http

--- a/charts/flux-operator-mcp/values.schema.json
+++ b/charts/flux-operator-mcp/values.schema.json
@@ -351,6 +351,20 @@
                 }
             }
         },
+        "service": {
+            "type": "object",
+            "properties": {
+                "ipFamilyPolicy": {
+                    "type": "string",
+                    "enum": [
+                        "",
+                        "SingleStack",
+                        "PreferDualStack",
+                        "RequireDualStack"
+                    ]
+                }
+            }
+        },
         "serviceAccount": {
             "default": {
                 "automount": true,

--- a/charts/flux-operator-mcp/values.yaml
+++ b/charts/flux-operator-mcp/values.yaml
@@ -131,3 +131,7 @@ httpRoute: # @schema default: {"enabled":false,"annotations":{},"parentRefs":[],
   #   sectionName: https
   hostnames: [ ] # @schema item: string ; uniqueItems: true
   # - flux-operator-mcp.example.com
+
+service:
+  # -- Sets the IP family policy on all Service resources. Uses Kubernetes defaults if unset
+  ipFamilyPolicy: '' # @schema type: string; enum:['', SingleStack, PreferDualStack, RequireDualStack]

--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -75,6 +75,7 @@ see the Flux Operator [documentation](https://fluxoperator.dev/docs/).
 | reporting | object | `{"interval":"5m"}` | Flux [reporting](https://fluxoperator.dev/docs/crd/fluxreport/) settings. |
 | resources | object | `{"limits":{"cpu":"2000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
+| service.ipFamilyPolicy | string | `""` | Sets the IP family policy on all Service resources. Uses Kubernetes defaults if unset |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
 | serviceMonitor | object | `{"create":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |
 | tolerations | list | `[]` | Pod tolerations settings. |

--- a/charts/flux-operator/templates/service.yaml
+++ b/charts/flux-operator/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: 8080
       targetPort: http-metrics

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -378,6 +378,20 @@
                 }
             }
         },
+        "service": {
+            "type": "object",
+            "properties": {
+                "ipFamilyPolicy": {
+                    "type": "string",
+                    "enum": [
+                        "",
+                        "SingleStack",
+                        "PreferDualStack",
+                        "RequireDualStack"
+                    ]
+                }
+            }
+        },
         "serviceAccount": {
             "default": {
                 "automount": true,

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -183,6 +183,10 @@ serviceMonitor: # @schema default: {"create":false,"interval":"60s","scrapeTimeo
   scrapeTimeout: 30s
   labels: { }
 
+service:
+  # -- Sets the IP family policy on all Service resources. Uses Kubernetes defaults if unset
+  ipFamilyPolicy: '' # @schema type: string; enum:['', SingleStack, PreferDualStack, RequireDualStack]
+
 # -- Marketplace settings.
 marketplace:
   type: ""


### PR DESCRIPTION
It's unset by default so that Kubernetes defaults are being used. Users can overwrite it to use dual stack networking instead.

Fixes #179