### PR TITLE
ci: Run validation with flux-schema

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup yq
-        uses: fluxcd/pkg/actions/yq@main
-      - name: Setup kubeconform
-        uses: fluxcd/pkg/actions/kubeconform@main
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@04acaec6161ac4fb1a82ffafa88901c03271d34f # v2.8.6
+      - name: Setup Flux Schema CLI
+        uses: fluxcd/flux-schema/actions/setup@c90d3f83707614d21c20226183a9e714d8ba9626 # v0.3.0
       - name: Setup Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Setup Helm Docs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # Makefile for building, testing, and publishing the ControlPlane Helm Charts.
 
+# Prerequisites
+# - brew install flux kubectl yq helm helm-docs
+# - go install github.com/fluxcd/flux-schema/cmd/flux-schema@latest
+# - helm plugin install https://github.com/losisin/helm-values-schema-json.git --verify=false
+
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -20,6 +20,6 @@ for pkg in ${REPOSITORY_ROOT}/charts/*; do
     break
   fi
   chartName=${pkg##*/}
-  info "Running helm template and kubeconform for ${chartName}"
-  helm template ${chartName} --include-crds ${pkg} | kubeconform -strict -ignore-missing-schemas -verbose
+  info "Running helm template and flux-schema for ${chartName}"
+  helm template ${chartName} --include-crds ${pkg} | flux-schema validate --verbose
 done


### PR DESCRIPTION
Switch from kubeconform to [flux-schema](https://github.com/fluxcd/flux-schema) which can properly validate all Flux CRDs. 