### PR TITLE
feat(flux-operator): add strategy value

### DIFF
--- a/charts/flux-operator/README.md
+++ b/charts/flux-operator/README.md
@@ -78,6 +78,7 @@ see the Flux Operator [documentation](https://fluxoperator.dev/docs/).
 | service.ipFamilyPolicy | string | `""` | Sets the IP family policy on all Service resources. Uses Kubernetes defaults if unset |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
 | serviceMonitor | object | `{"create":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |
+| strategy | object | `{}` | Deployment update strategy. Set `{"type":"Recreate"}` for single-replica installs whose web UI is fronted by a load balancer health check, where a rolling update would otherwise deadlock. |
 | tolerations | list | `[]` | Pod tolerations settings. |
 | web.config | object | `{}` | The spec of the [Web Config API](https://fluxoperator.dev/docs/web-ui/web-config-api/) |
 | web.configSecretName | string | `""` | Reference to an existing Secret in the same namespace as the deployment containing the Web Config API. Should have the key `config.yaml`. |

--- a/charts/flux-operator/templates/deployment.yaml
+++ b/charts/flux-operator/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
   {{- if include "flux-operator.setWebServerReplicas" . }}
   replicas: {{ .Values.web.serverReplicas }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "flux-operator.selectorLabels" . | nindent 6 }}

--- a/charts/flux-operator/values.schema.json
+++ b/charts/flux-operator/values.schema.json
@@ -433,6 +433,9 @@
                 }
             }
         },
+        "strategy": {
+            "type": "object"
+        },
         "tolerations": {
             "type": "array",
             "uniqueItems": true,

--- a/charts/flux-operator/values.yaml
+++ b/charts/flux-operator/values.yaml
@@ -162,6 +162,9 @@ tolerations: [ ] # @schema item: object ; uniqueItems: true
 # -- Pod Node Selector settings.
 nodeSelector: { } # @schema type: object
 
+# -- Deployment update strategy. Set `{"type":"Recreate"}` for single-replica installs whose web UI is fronted by a load balancer health check, where a rolling update would otherwise deadlock.
+strategy: { } # @schema type: object
+
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false
 


### PR DESCRIPTION
## What

Add an optional `strategy` value to the `flux-operator` chart, wired into the Deployment's `spec.strategy`. Default is empty `{}`, so the rendered Deployment is unchanged (Kubernetes default `RollingUpdate`) for existing users.

## Why

The operator runs as a single replica and its web UI (`:9080`) serves only on the elected leader ([`<-mgr.Elected()`](https://github.com/controlplaneio-fluxcd/flux-operator/blob/6f2cf7b6243898189e51762392a0869068467405/cmd/operator/main.go#L441-L442)). When that port is exposed through a load balancer that health-checks the pod on `9080` (e.g. a GKE Gateway/NEG, whose default backend health check probes the serving port, not the `:8081` readiness probe), a rolling update **deadlocks**:

- `maxUnavailable` rounds to `0` for a single replica, so the old pod can't be removed until the new one is Ready;
- the new (surge) pod is never the leader, so it never serves `9080`, never passes the LB health check, and never becomes Ready.

The rollout hangs and `helm upgrade --wait` times out. Setting `strategy: {type: Recreate}` resolves it (old pod terminates first; the single new pod becomes leader and serves `9080`). Today the chart exposes no way to set this, forcing a post-render or out-of-band patch.

## Change

- `values.yaml`: new `strategy: {}` value (documented, opt-in).
- `templates/deployment.yaml`: render `spec.strategy` only when set (`{{- with .Values.strategy }}`).
- Regenerated `values.schema.json` + `README.md` via `make manifests`.

No `Chart.yaml` version bump (left to maintainers, per repo convention).

## Testing

- `helm template --set strategy.type=Recreate` renders `spec.strategy.type: Recreate`; default render (no `strategy`) is byte-for-byte unchanged.
- `helm lint charts/flux-operator` passes.
- `make manifests` produces no drift beyond the new value.
