### PR TITLE
feat: support creation of pull secret via values

### DIFF
--- a/charts/flux-instance/README.md
+++ b/charts/flux-instance/README.md
@@ -46,7 +46,8 @@ helm -n flux-system uninstall flux
 | instance.kustomize.patches | list | `[]` | Kustomize patches https://fluxoperator.dev/docs/crd/fluxinstance/#kustomize-patches |
 | instance.sharding | object | `{"key":"sharding.fluxcd.io/key","shards":[]}` | Sharding https://fluxoperator.dev/docs/crd/fluxinstance/#sharding-configuration |
 | instance.storage | object | `{"class":"","size":""}` | Storage https://fluxoperator.dev/docs/crd/fluxinstance/#storage-configuration |
-| instance.sync | object | `{"interval":"1m","kind":"GitRepository","name":"","path":"","provider":"","pullSecret":"","ref":"","url":""}` | Sync https://fluxoperator.dev/docs/crd/fluxinstance/#sync-configuration |
+| instance.sync | object | `{"interval":"1m","kind":"GitRepository","name":"","path":"","provider":"","pullSecret":"","pullSecretStringData":{},"ref":"","url":""}` | Sync https://fluxoperator.dev/docs/crd/fluxinstance/#sync-configuration |
+| instance.sync.pullSecretStringData | object | `{}` | Creates secret and sets it as pullSecret |
 | nameOverride | string | `""` |  |
 
 ## Source Code

--- a/charts/flux-instance/templates/instance.yaml
+++ b/charts/flux-instance/templates/instance.yaml
@@ -58,7 +58,9 @@ spec:
     {{- if .Values.instance.sync.provider }}
     provider: {{ .Values.instance.sync.provider }}
     {{- end }}
-    {{- if .Values.instance.sync.pullSecret }}
+    {{- if .Values.instance.sync.pullSecretStringData }}
+    pullSecret: {{ printf "%s-pull" (include "flux-instance.fullname" . ) }}
+    {{- else if .Values.instance.sync.pullSecret }}
     pullSecret: {{ .Values.instance.sync.pullSecret }}
     {{- end }}
   {{- end }}

--- a/charts/flux-instance/templates/pullsecret.yaml
+++ b/charts/flux-instance/templates/pullsecret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.instance.sync.pullSecretStringData }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-pull-secret" (include "flux-instance.fullname" . ) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flux-instance.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+stringData:
+  {{- toYaml .Values.instance.sync.pullSecretStringData | nindent 2 }}
+{{- end }}

--- a/charts/flux-instance/values.schema.json
+++ b/charts/flux-instance/values.schema.json
@@ -427,6 +427,10 @@
                         "pullSecret": {
                             "type": "string"
                         },
+                        "pullSecretStringData": {
+                            "type": "object",
+                            "properties": {}
+                        },
                         "ref": {
                             "type": "string"
                         },

--- a/charts/flux-instance/values.yaml
+++ b/charts/flux-instance/values.yaml
@@ -46,6 +46,8 @@ instance:
     ref: ""
     path: ""
     pullSecret: ""
+    # -- Creates secret and sets it as pullSecret
+    pullSecretStringData: {}
     name: ""
     provider: ""
   kustomize: # @schema required: false


### PR DESCRIPTION
Thanks for your work with the Flux Operator - it helps me a lot! 😄

I'm currently working on Cluster API based setup and for this I'm using Flux' [Remote Cluster feature](https://fluxcd.io/flux/components/helm/helmreleases/#remote-cluster-api-clusters) to deploy the Flux instances into the workload clusters.

Unfortunately I have no solution for the creation of the pull secret yet. I found [this PR (#65)](https://github.com/controlplaneio-fluxcd/charts/pull/65) which would fit perfectly. Therefore I decided to revive the PR and hope it get's merged this time...

Example usage:

```yaml
  sync:
    # pullSecret: ''
    pullSecretStringData:
      username: user
      password: password
```